### PR TITLE
Fix suggestions

### DIFF
--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -52,6 +52,7 @@ export async function getSuggestions(videoId: string): Promise<MusicVideo[]> {
         params: 'mgMDCNgE',
         playerParams: 'igMDCNgE',
         tunerSettingValue: 'AUTOMIX_SETTING_NORMAL',
+        playlistId: "RDAMVM" + videoId,
         videoId,
       },
       searchParams: {


### PR DESCRIPTION
Fixes #9. Youtube only returns suggestions if we pass in a `playlistId` in the json body.

Not sure what `RDAMVM` stands for, but that's what Youtube puts. I'm sure it means something to someone.