### PR TITLE
fix for artists without a navigationEndpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-youtube-music",
   "description": "Unofficial YouTube Music API for Node.js",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "repository": "https://github.com/baptisteArno/node-youtube-music",

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -20,15 +20,22 @@ const getAlbumType = (typeText:string):AlbumType =>{
     default:
       return AlbumType.single;
   }
-} 
+}
 // Detects multiple artists of the MusicVideo
-export const listArtists = (data: any[]): {name:string; id:string}[] => {
-  const artists:{name:string; id:string}[] = [];
+export const listArtists = (data: any[]): {name:string; id?:string}[] => {
+  const artists:{name:string; id?:string}[] = [];
   data.forEach(item =>{
     if(item.navigationEndpoint && item.navigationEndpoint.browseEndpoint.browseEndpointContextSupportedConfigs.browseEndpointContextMusicConfig.pageType === PageType.artist) {
       artists.push({name:item.text, id: item.navigationEndpoint.browseEndpoint.browseId})
     }
   })
+  if(artists.length === 0){
+    const delimiterIndex = data.findIndex(item => item.text === ' • ');
+    if(delimiterIndex !== -1){
+      data.filter((item, index) => index < delimiterIndex && item.name !== ' & ')
+          .forEach(item => artists.push({name:item.text}))
+    }
+  }
   return artists;
 }
 
@@ -809,7 +816,7 @@ const parseArtistsSuggestionsItem = (item: {
     thumbnailUrl = item.musicTwoRowItemRenderer.thumbnailRenderer.musicThumbnailRenderer.thumbnail.thumbnails.pop()?.url;
   } catch (e) {
     console.error("Couldn't get thumbnailUrl", e);
-    
+
   }
   return {
     artistId,
@@ -850,7 +857,7 @@ export const parseArtistData = (body:{
         }
       }
     }
-  }; 
+  };
   contents:{
     singleColumnBrowseResultsRenderer:{
       tabs:{
@@ -953,7 +960,7 @@ artistId:string):Artist =>{
   } catch (e) {
     console.error("Couldn't get artist description", e)
   }
-  
+
   const thumbnails:any[] = [];
   try {
     const thumbnailArray = body.header.musicImmersiveHeaderRenderer.thumbnail.musicThumbnailRenderer.thumbnail.thumbnails
@@ -982,7 +989,7 @@ artistId:string):Artist =>{
         if(shelf.musicCarouselShelfRenderer.contents[0].musicTwoRowItemRenderer.title.runs[0].navigationEndpoint?.browseEndpoint.browseEndpointContextSupportedConfigs.browseEndpointContextMusicConfig.pageType === PageType.album)
           shelf.musicCarouselShelfRenderer.contents.forEach(item=>{
             const parsedItem = parseArtistsAlbumItem(item)
-            if(parsedItem.type === AlbumType.single) 
+            if(parsedItem.type === AlbumType.single)
               singles.push(parsedItem);
             else
               albums.push(parsedItem);

--- a/test/artist.test.ts
+++ b/test/artist.test.ts
@@ -1,4 +1,4 @@
-import {searchArtists, getArtist} from '../src';
+import {searchArtists, getArtist, searchMusics} from '../src';
 
 test('Search for Dua Lipa and get more data', async () => {
   const query = 'Dua Lipa';
@@ -14,3 +14,14 @@ test('Search for Dua Lipa and get more data', async () => {
   expect(data.singles?.length).toBeGreaterThanOrEqual(1)
   console.log(data)
 });
+
+test("Parse artist for songs whose artist does not have a navigationEndpoint", async () => {
+  const query = "Running in the 90s";
+
+  const results = await searchMusics(query);
+  expect(results.length).toBeGreaterThanOrEqual(1);
+  const firstResult = results[0];
+  expect(firstResult).toBeDefined();
+  expect(firstResult.artists?.length).toBeGreaterThanOrEqual(1);
+  console.log(firstResult.artists);
+})


### PR DESCRIPTION
Some songs ([example](https://music.youtube.com/watch?v=_Fxil2QY0wE)) don't have a navigationEndpoint on their artist. This happens when the artist's name is not clickable in the client, usually when youtube doesn't have a channel page for them. This results in an empty array being returned by the package.

Fixed it by manually looking for the delimiter ` • ` and parsing everything before it.

If the song contains both artists with and without a navigationEndpoint, currently it will return only the artists with one. Haven't found any such songs yet though.