### PR TITLE
Fix destructuring crash for empty playlist search results

### DIFF
--- a/src/searchPlaylists.ts
+++ b/src/searchPlaylists.ts
@@ -7,9 +7,14 @@ export const parseSearchPlaylistsBody = (
   body: any,
   onlyOfficialPlaylists: boolean
 ): PlaylistPreview[] => {
-  const { contents } =
+  const contents =
     body.contents.tabbedSearchResultsRenderer.tabs[0].tabRenderer.content.sectionListRenderer.contents.pop()
-      .musicShelfRenderer;
+      .musicShelfRenderer?.contents;
+
+  if (!contents) {
+    return [];
+  }
+
 
   const results: PlaylistPreview[] = [];
 


### PR DESCRIPTION
When searching for playlists but there's no results, the library throws the error:

```
TypeError: Cannot destructure property 'contents' of 'e.contents.tabbedSearchResultsRenderer.tabs[0].tabRenderer.content.sectionListRenderer.contents.pop(...).musicShelfRenderer' as it is undefined.
```

I've modified the code in `searchPlaylists.ts` to not use shorthand object destructuring, to do it safely instead. If the destructuring was detected to be unsuccessful then the function returns an empty array to represent no search results.