### PR TITLE
Fix:  listMusicsFromPlaylist 400 Bad request error #15

### DIFF
--- a/src/listMusicsFromPlaylist.ts
+++ b/src/listMusicsFromPlaylist.ts
@@ -40,12 +40,18 @@ export const parseListMusicsFromPlaylistBody = (body: {
 export async function listMusicsFromPlaylist(
   playlistId: string
 ): Promise<MusicVideo[]> {
+  let browseId;
+
+  if (!playlistId.startsWith('VL')) {
+    browseId = 'VL' + playlistId;
+  }
+
   const response = await got.post(
     'https://music.youtube.com/youtubei/v1/browse?alt=json&key=AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30',
     {
       json: {
         ...context.body,
-        browseId: playlistId,
+        browseId,
       },
       headers: {
         'User-Agent':

--- a/src/listMusicsFromPlaylist.ts
+++ b/src/listMusicsFromPlaylist.ts
@@ -37,6 +37,7 @@ export const parseListMusicsFromPlaylistBody = (body: {
   return results;
 };
 
+
 export async function listMusicsFromPlaylist(
   playlistId: string
 ): Promise<MusicVideo[]> {
@@ -46,24 +47,25 @@ export async function listMusicsFromPlaylist(
     browseId = 'VL' + playlistId;
   }
 
-  const response = await got.post(
-    'https://music.youtube.com/youtubei/v1/browse?alt=json&key=AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30',
-    {
-      json: {
-        ...context.body,
-        browseId,
-      },
-      headers: {
-        'User-Agent':
-          'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-        origin: 'https://music.youtube.com',
-      },
-    }
-  );
   try {
+    const response = await got.post(
+      'https://music.youtube.com/youtubei/v1/browse?alt=json&key=AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30',
+      {
+        json: {
+          ...context.body,
+          browseId,
+        },
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+          origin: 'https://music.youtube.com',
+        },
+      }
+    );
     return parseListMusicsFromPlaylistBody(JSON.parse(response.body));
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error(`Error in listMusicsFromPlaylist: ${error}`);
     return [];
   }
 }
+


### PR DESCRIPTION
Realized this error still exists while using code from this repository. Is has to do with the `playlistId` prefix

For example passing `PLMgLYyo3mS5w4zkIIeFPAMWSIr_wJ5STx` as the `browseId` returns a `400 Bad Request response` but prefixing with `VL` resolves the request

> The VL prefix was added in 2019, when YouTube Music launched. Before that, all YouTube Music playlist IDs were simply a string of letters and numbers.
> 
> The VL prefix is not used for YouTube Music playlists that were created before 2019. These playlists will still have the original string of letters and numbers as their ID.

> -- via Bard